### PR TITLE
Fix for broken backups on sites with alternate install_method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ before_install:
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.
-  - sudo docker-compose -f docker-compose-provision.yml run hostmaster
+  - sudo docker-compose -f docker-compose-provision.yml run -T -e TERM=xterm hostmaster

--- a/platform/backup.provision.inc
+++ b/platform/backup.provision.inc
@@ -16,7 +16,7 @@ function drush_provision_drupal_provision_backup_validate($backup_file = NULL) {
       drush_set_context('DRUSH_ERROR_CODE', DRUSH_SUCCESS);
     }
   }
-  if (!drush_get_option('installed') && !drush_get_option('force', false)) {
+  if (!_provision_drupal_site_exists() && !drush_get_option('force', false)) {
      drush_set_error('PROVISION_DRUPAL_SITE_NOT_FOUND');
    }
 

--- a/platform/provision_drupal.drush.inc
+++ b/platform/provision_drupal.drush.inc
@@ -55,7 +55,7 @@ function provision_drupal_drush_exit() {
 
   if (preg_match("/^provision-/", $command[0]) && drush_get_option('provision_save_config', TRUE)) {
     if (d()->type === 'site') {
-      if (drush_get_option('installed')) {
+      if (_provision_drupal_site_exists()) {
         // Don't generate the drushrc.php on provision-save/delete commands.
         if (!preg_match("/^provision-(save|delete)/", $command[0])) {
           provision_save_site_data();

--- a/platform/verify.provision.inc
+++ b/platform/verify.provision.inc
@@ -65,8 +65,10 @@ function drush_provision_drupal_pre_provision_verify() {
       
       // Change current directory to makefile's directory until Drush fixes this bug: https://github.com/drush-ops/drush/issues/2482
       // @TODO: Remove this once is committed.
-      chdir(dirname(d()->makefile));
-      
+      if (!empty(d()->makefile) && file_exists(dirname(d()->makefile))) {
+        chdir(dirname(d()->makefile));
+      }
+
       drush_invoke_process('@none', "make", $arguments, $options);
       if (drush_get_error()) {
         return drush_set_error("DRUSH_MAKE_FAILED",


### PR DESCRIPTION
Found another place where drush option "installed" is checked. 

If install_method is not profile, this option is never set.

https://www.drupal.org/node/2754069#comment-12168870