### PR TITLE
Issue #2926905: Disable caching on CiviCRM paths with i18n prefixes.

### DIFF
--- a/http/Provision/Config/Nginx/Inc/vhost_include.tpl.php
+++ b/http/Provision/Config/Nginx/Inc/vhost_include.tpl.php
@@ -433,7 +433,7 @@ location ^~ /admin {
 ### Avoid caching /civicrm* and protect it from bots.
 ### Support i18n path prefixes, ex: /fr/civicrm*.
 ###
-location ~* ^/(\w\w/?)civicrm {
+location ~* ^/(\w\w/)?civicrm {
   if ($is_bot) {
     return 403;
   }

--- a/http/Provision/Config/Nginx/Inc/vhost_include.tpl.php
+++ b/http/Provision/Config/Nginx/Inc/vhost_include.tpl.php
@@ -431,8 +431,9 @@ location ^~ /admin {
 
 ###
 ### Avoid caching /civicrm* and protect it from bots.
+### Support i18n path prefixes, ex: /fr/civicrm*.
 ###
-location ^~ /civicrm {
+location ~* ^/(\w\w/?)civicrm {
   if ($is_bot) {
     return 403;
   }


### PR DESCRIPTION
https://www.drupal.org/project/provision/issues/2926905