### PR TITLE
Fix drupal 7 settings template (platform->publish_path removed)

### DIFF
--- a/Provision/Config/Drupal/provision_drupal_settings_7.tpl.php
+++ b/Provision/Config/Drupal/provision_drupal_settings_7.tpl.php
@@ -163,8 +163,8 @@ if (isset($_SERVER['db_name'])) {
   }
 
   # Additional platform wide configuration settings.
-  if (is_readable('<?php print $this->platform->publish_path  ?>/sites/all/platform.settings.php')) {
-    include_once('<?php print $this->platform->publish_path ?>/sites/all/platform.settings.php');
+  if (is_readable('<?php print $this->platform->root  ?>/sites/all/platform.settings.php')) {
+    include_once('<?php print $this->platform->root ?>/sites/all/platform.settings.php');
   }
 
   # Additional site configuration settings.


### PR DESCRIPTION
$this->platform->publish_path seems to be removed from the platform context and thus in a sites settings.php the platform settings code results in:
```# Additional platform wide configuration settings.
  if (is_readable('/sites/all/platform.settings.php')) {
    include_once('/sites/all/platform.settings.php');```

platform->root seems to yield the correct path to the platform