### PR TITLE
Remove session save handler from d6 settings tpl

### DIFF
--- a/Provision/Config/Drupal/provision_drupal_settings_6.tpl.php
+++ b/Provision/Config/Drupal/provision_drupal_settings_6.tpl.php
@@ -126,7 +126,6 @@ if (isset($_SERVER['db_name'])) {
   ini_set('session.cache_limiter',    'none');
   ini_set('session.cookie_lifetime',  0);
   ini_set('session.gc_maxlifetime',   200000);
-  ini_set('session.save_handler',     'user');
   ini_set('session.use_only_cookies', 1);
   ini_set('session.use_trans_sid',    0);
   ini_set('url_rewriter.tags',        '');


### PR DESCRIPTION
This throws an error in php7.2 (`Cannot set 'user' save handler by ini_set() or session_module_name()`) [as noted in the PHP changelog](https://secure.php.net/manual/en/migration72.other-changes.php#migration72.other-changes.session-module-name) and has been removed from the default settings template in the [d6 lts project](https://github.com/d6lts/drupal/commit/c9b85e7b405a592b73335daa266cdcc3015e057e)